### PR TITLE
Fix twin icons for DROPDOWN selectorStyle

### DIFF
--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -50,6 +50,7 @@ class SelectorButton extends StatelessWidget {
                     textStyle: selectorTextStyle,
                   ),
                   value: country,
+                  icon: SizedBox.shrink(),
                   items: mapCountryToDropdownItem(countries),
                   onChanged: isEnabled ? onCountryChanged : null,
                 ),


### PR DESCRIPTION
simple set icon to SizedBox.shrink to remove default one

Fixes https://github.com/SahanMonaara/intl_phone_number_input_v2/issues/4