### PR TITLE
Customizable dropdownColor and cursorColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add `intl_phone_number_input_v2` to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  intl_phone_number_input_v2: ^0.0.2
+  intl_phone_number_input_v2: ^0.0.8
 ```
 
 Then, run `flutter pub get` to install the package.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,6 +53,8 @@ class _MyHomePageState extends State<MyHomePage> {
               selectorConfig: SelectorConfig(
                 selectorType: PhoneInputSelectorType.BOTTOM_SHEET,
                 useBottomSheetSafeArea: true,
+                cursorColor: Colors.black,
+                dropdownColor: Colors.grey,
               ),
               ignoreBlank: false,
               autoValidateMode: AutovalidateMode.disabled,

--- a/lib/src/utils/selector_config.dart
+++ b/lib/src/utils/selector_config.dart
@@ -36,6 +36,12 @@ class SelectorConfig {
   /// Use safe area for selectorType=BOTTOM_SHEET
   final bool useBottomSheetSafeArea;
 
+  /// Color for a dropdown arrow icon, grey by default
+  final Color? dropdownColor;
+
+  /// Color for the cursor in dropdown country search
+  final Color? cursorColor;
+
   const SelectorConfig({
     this.selectorType = PhoneInputSelectorType.DROPDOWN,
     this.showFlags = true,
@@ -45,5 +51,7 @@ class SelectorConfig {
     this.leadingPadding,
     this.trailingSpace = true,
     this.useBottomSheetSafeArea = false,
+    this.dropdownColor = Colors.grey,
+    this.cursorColor = Colors.black,
   });
 }

--- a/lib/src/widgets/countries_search_list_widget.dart
+++ b/lib/src/widgets/countries_search_list_widget.dart
@@ -7,6 +7,7 @@ import 'package:intl_phone_number_input_v2/src/utils/util.dart';
 class CountrySearchListWidget extends StatefulWidget {
   final List<Country> countries;
   final InputDecoration? searchBoxDecoration;
+  final Color? cursorColor;
   final String? locale;
   final ScrollController? scrollController;
   final bool autoFocus;
@@ -17,6 +18,7 @@ class CountrySearchListWidget extends StatefulWidget {
     this.countries,
     this.locale, {
     this.searchBoxDecoration,
+    this.cursorColor,
     this.scrollController,
     this.showFlags,
     this.useEmoji,
@@ -67,7 +69,7 @@ class _CountrySearchListWidgetState extends State<CountrySearchListWidget> {
             decoration: getSearchBoxDecoration(),
             controller: _searchController,
             autofocus: widget.autoFocus,
-            cursorColor: Colors.black,
+            cursorColor: widget.cursorColor,
             onChanged: (value) {
               final String value = _searchController.text.trim();
               return setState(

--- a/lib/src/widgets/item.dart
+++ b/lib/src/widgets/item.dart
@@ -8,6 +8,7 @@ class Item extends StatelessWidget {
   final bool? showFlag;
   final bool? useEmoji;
   final TextStyle? textStyle;
+  final Color? dropdownColor;
   final bool withCountryNames;
   final double? leadingPadding;
   final bool trailingSpace;
@@ -18,6 +19,7 @@ class Item extends StatelessWidget {
     this.showFlag,
     this.useEmoji,
     this.textStyle,
+    this.dropdownColor,
     this.withCountryNames = false,
     this.leadingPadding = 12,
     this.trailingSpace = true,
@@ -48,7 +50,7 @@ class Item extends StatelessWidget {
           ),
           Icon(
             Icons.keyboard_arrow_down_sharp,
-            color: Colors.grey,
+            color: dropdownColor,
             size: 14,
           ),
         ],

--- a/lib/src/widgets/selector_button.dart
+++ b/lib/src/widgets/selector_button.dart
@@ -48,6 +48,7 @@ class SelectorButton extends StatelessWidget {
                     leadingPadding: selectorConfig.leadingPadding,
                     trailingSpace: selectorConfig.trailingSpace,
                     textStyle: selectorTextStyle,
+                    dropdownColor: selectorConfig.dropdownColor,
                   ),
                   value: country,
                   items: mapCountryToDropdownItem(countries),
@@ -61,6 +62,7 @@ class SelectorButton extends StatelessWidget {
                 leadingPadding: selectorConfig.leadingPadding,
                 trailingSpace: selectorConfig.trailingSpace,
                 textStyle: selectorTextStyle,
+                dropdownColor: selectorConfig.dropdownColor,
               )
         : MaterialButton(
             key: Key(TestHelper.DropdownButtonKeyValue),
@@ -92,6 +94,7 @@ class SelectorButton extends StatelessWidget {
                 leadingPadding: selectorConfig.leadingPadding,
                 trailingSpace: selectorConfig.trailingSpace,
                 textStyle: selectorTextStyle,
+                dropdownColor: selectorConfig.dropdownColor,
               ),
             ),
           );
@@ -111,6 +114,7 @@ class SelectorButton extends StatelessWidget {
           textStyle: selectorTextStyle,
           withCountryNames: false,
           trailingSpace: selectorConfig.trailingSpace,
+          dropdownColor: selectorConfig.dropdownColor,
         ),
       );
     }).toList();
@@ -133,6 +137,7 @@ class SelectorButton extends StatelessWidget {
               countries,
               locale,
               searchBoxDecoration: searchBoxDecoration,
+              cursorColor: selectorConfig.cursorColor,
               showFlags: selectorConfig.showFlags,
               useEmoji: selectorConfig.useEmoji,
               autoFocus: autoFocusSearchField,
@@ -181,6 +186,7 @@ class SelectorButton extends StatelessWidget {
                       countries,
                       locale,
                       searchBoxDecoration: searchBoxDecoration,
+                      cursorColor: selectorConfig.cursorColor,
                       scrollController: controller,
                       showFlags: selectorConfig.showFlags,
                       useEmoji: selectorConfig.useEmoji,


### PR DESCRIPTION
Colors were set to `Colors.black` and` Colors.grey` - as they are still set by default. But in dark mode these colors need to be customizable via `Theme` or `SelectorConfig` (as I implemented now)